### PR TITLE
Set timeout for socket before connect, not after

### DIFF
--- a/send_nsca/nsca.py
+++ b/send_nsca/nsca.py
@@ -366,10 +366,10 @@ class NscaSender(object):
                 host, port, socket.AF_UNSPEC, socket.SOCK_STREAM, 0, 0):
             try:
                 s = socket.socket(family, socktype, proto)
-                s.connect(sockaddr)
-                conns.append(s)
                 if timeout is not None:
                     s.settimeout(timeout)
+                s.connect(sockaddr)
+                conns.append(s)
                 if not connect_all:
                     break
             except socket.error:


### PR DESCRIPTION
As the version before this fix took more than 2 minutes to timeout the connect to sockaddr.

```
time ./passive_check.py apt
Passive check apt exiting due to exception
Traceback (most recent call last):
  File "./passive_check.py", line 138, in <module>
    main()
  File "./passive_check.py", line 132, in main
    sender.send_service(minion_id, check_name, status, output)
  File "/usr/local/nagios/local/lib/python2.7/site-packages/send_nsca/nsca.py", line 351, in send_service
    self.connect()
  File "/usr/local/nagios/local/lib/python2.7/site-packages/send_nsca/nsca.py", line 391, in connect
    conns = self._sock_connect(self.remote_host, self.port, self.timeout, connect_all=self.send_to_all)
  File "/usr/local/nagios/local/lib/python2.7/site-packages/send_nsca/nsca.py", line 378, in _sock_connect
    raise socket.error("could not connect to %s:%d" % (self.remote_host, self.port))
error: could not connect to 8.8.8.8:5667

real    2m9.115s
```
