### PR TITLE
Add support for Rijndael algorithms (encryption methods 14, 15, and 16)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
     - "2.6"
     - "2.7"
 install:
-    - "sudo apt-get install nsca"
+    - "sudo apt-get install libmcrypt-dev nsca"
     - "pip install -r requirements.txt -r requirements-tests.txt --use-mirrors"
+    - "pip install python-mcrypt --allow-external python-mcrypt --allow-unverified python-mcrypt"
 script: "nosetests tests"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     scripts=["bin/py_send_nsca"],
     packages=["send_nsca"],
     provides=["send_nsca"],
-    install_requires=["pycrypto>=2.0.0"],
+    install_requires=["mcrypt", "pycrypto>=2.0.0"],
     tests_require=["nose", "mock==1.0.1"],
     long_description="""send_nsca -- a pure-python nsca sender
 

--- a/tests/integration/test_crypters.py
+++ b/tests/integration/test_crypters.py
@@ -40,3 +40,15 @@ class TestCAST128Crypter(TestCrypter):
 
 class TestBlowFishCrypter(TestCrypter):
     crypto_method = 8
+
+
+class TestRijndael128Crypter(TestCrypter):
+    crypto_method = 14
+
+
+class TestRijndael192Crypter(TestCrypter):
+    crypto_method = 15
+
+
+class TestRijndael256Crypter(TestCrypter):
+    crypto_method = 16


### PR DESCRIPTION
The code was previous attempting to use PyCrypto's AES module to
implement these methods.  That did not work because they are actually
Rijndael ciphers and AES-256 is not the same as Rijndael-256 (and
similarly with 128 and 192)¹.  It is possible to implement Rijndael-128
using PyCrypto's AES module by setting the key_size to 32.
Unfortunately, it is not possible to do so for Rijndael-192 or
Rijndael-256.

To support all three Rijndael methods, the mcrypt module is needed.
Rather than use PyCrypto for just one of the Rijndael methods, replace
all three with an mcrypt version.

¹ http://stackoverflow.com/a/8355432

I attempted to run the unit tests but they failed for me, initially because they rely on a non-upstream [patch to nsca from debian](https://sources.debian.net/src/nsca/2.9.1-3.1/debian/patches/02_nsca_foreground.dpatch/), but even when running from an ubuntu system I had no luck.

I have been using this on production systems for a month or so though, FWIW.

Thanks for this module, it's been a great help!
